### PR TITLE
Add standard, active classes to slide indicator

### DIFF
--- a/lib/src/slides/slides.component.html
+++ b/lib/src/slides/slides.component.html
@@ -1,6 +1,6 @@
 <AbsoluteLayout width="100%">
 	<ng-content></ng-content>
 	<StackLayout *ngIf="pageIndicators" #footer style="width:100%; height:20%;">
-		<Label *ngFor="let indicator of indicators" [class.slide-indicator-active]="indicator.active == true" [class.slide-indicator-inactive]="indicator.active == false	"></Label>
+		<Label *ngFor="let indicator of indicators" class="slide-indicator" [class.active]="indicator.active == true" [class.slide-indicator-active]="indicator.active == true" [class.slide-indicator-inactive]="indicator.active == false	"></Label>
 	</StackLayout>
 </AbsoluteLayout>


### PR DESCRIPTION
Adding a standard class to the slide indicators while adding an active class when they're active will let people animate transitions between states. The rest can be left alone to not break anybody's implementation now.